### PR TITLE
Add SubCategory support in AppDbContext

### DIFF
--- a/subway_project.Server/Data/AppDbContext.cs
+++ b/subway_project.Server/Data/AppDbContext.cs
@@ -11,7 +11,7 @@ namespace subway_project.Server.Data
         }
 
         public DbSet<Category> Categories { get; set; }
-        /*public DbSet<SubCategory> SubCategories { get; set; }*/
+        public DbSet<SubCategory> SubCategories { get; set; }
         public DbSet<Order> Orders { get; set; }
         public DbSet<Product> Products { get; set; }
         public DbSet<Queue> Queues { get; set; }
@@ -22,9 +22,9 @@ namespace subway_project.Server.Data
             modelBuilder.Entity<Category>()
                 .HasIndex(c => c.Name)
                 .IsUnique();
-            /*modelBuilder.Entity<SubCategory>()
+            modelBuilder.Entity<SubCategory>()
                 .HasIndex(sc => sc.Name)
-                .IsUnique();*/
+                .IsUnique();
         }
     }
 


### PR DESCRIPTION
This commit introduces a `DbSet<SubCategory>` property to the `AppDbContext` class, enabling management of `SubCategory` entities. The previously commented-out line for `SubCategories` has been activated, and the model configuration for `SubCategory` now includes a unique index on the `Name` property.