### PR TITLE
Add GetOrders component to KitchenPage

### DIFF
--- a/subway_project.client/src/components/KitchenPage.vue
+++ b/subway_project.client/src/components/KitchenPage.vue
@@ -1,10 +1,12 @@
 <script>
-import MealOrders from "@/components/QueueComponents/MealOrders.vue";
+  import MealOrders from "@/components/QueueComponents/MealOrders.vue";
+  import GetOrders from "@/components/QueueComponents/GetOrders.vue";
 
 export default {
   name: "KitchenPage",
   components: {
     MealOrders,
+    GetOrders,
   },
   data() {
     return {
@@ -21,11 +23,14 @@ export default {
   <div class="kitchenpage">
     <div class="header-div"></div>
     <div class="main-content">
-      <div class="left-div">
+      <!--<div class="left-div">
         <MealOrders :list-title="listOneTitle" :list-items="listOneItems"></MealOrders>
       </div>
       <div class="right-div">
         <MealOrders :list-title="listTwoTitle" :list-items="listTwoItems"></MealOrders>
+      </div>-->
+      <div>
+        <GetOrders />
       </div>
     </div>
   </div>

--- a/subway_project.client/src/components/QueueComponents/GetOrders.vue
+++ b/subway_project.client/src/components/QueueComponents/GetOrders.vue
@@ -1,0 +1,73 @@
+<script setup>
+  import { ref, onMounted } from 'vue'
+
+const orders = ref([])
+const loading = ref(true)
+const error = ref(null)
+
+onMounted(async () => {
+  try {
+    const response = await fetch('/api/Orders')
+    if (!response.ok) {
+      throw new Error('Failed to fetch orders')
+    }
+    orders.value = await response.json()
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    loading.value = false
+  }
+})</script>
+
+<template>
+  <div>
+    <h2>Food Orders</h2>
+
+    <div v-if="loading">Loading orders...</div>
+    <div v-if="error">Error: {{ error }}</div>
+
+    <div class="left-div">
+      <p>orderReceived</p>
+      <ul v-if="!loading && !error">
+        <li v-for="order in orders" :key="order.id">
+          {{ order.id }} - {{ order.takeAway }} - {{ order.totalPrice }} - {{ order.orderReceived }}
+        </li>
+      </ul>
+    </div>
+    <br />
+    <div class="right-div">
+      <p>orderInProgress</p>
+      <ul v-if="!loading && !error">
+        <li v-for="order in orders" :key="order.id">
+          {{ order.id }} - {{ order.takeAway }} - {{ order.totalPrice }} - {{ order.orderInProgress }}
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+  .left-div {
+    width: 50%;
+    background-color: #e0e0e0;
+    padding: 20px;
+    margin-left: 1.5rem;
+    margin-right: 2rem;
+    margin-bottom: 2rem;
+    box-sizing: border-box;
+    float: left;
+    border: solid 5px blue;
+  }
+
+  .right-div {
+    width: 50%;
+    background-color: #e0e0e0;
+    padding: 20px;
+    margin-left: 1.5rem;
+    margin-right: 2rem;
+    margin-bottom: 2rem;
+    box-sizing: border-box;
+    float: left;
+    border: solid 5px yellow;
+  }
+</style>


### PR DESCRIPTION
Updated KitchenPage.vue to import and use the new GetOrders component for fetching and displaying food orders. The previous MealOrders layout was commented out.

Created GetOrders.vue with a script setup that utilizes Vue's Composition API to manage state and lifecycle. The template handles loading and error states, and displays orders in two sections: received and in progress, with scoped styles for layout.