### PR TITLE
Added reset of Pinia cart when logo in TopNav is clicked. Grouped items of the same product in CartNav and OrderConfirmation.

### DIFF
--- a/subway_project.client/src/components/CartNav.vue
+++ b/subway_project.client/src/components/CartNav.vue
@@ -12,11 +12,9 @@ const props = defineProps({
 
 const router = useRouter();
 
-  // The computed property groupedList can be removed once adding and removing procucts from Pinia cart is implemented.
-  // Or it can be updated to use the Pinia cart instead of the "props + emits" (i.e. receivedList) cart.
-/*const groupedList = computed(() => {
+const groupedList = computed(() => {
   const map = {}
-  for (const item of props.receivedList) {
+  for (const item of orderStore.order.products) {
     if (!map[item.name]) {
       map[item.name] = { ...item, quantity: 1 }
     } else {
@@ -24,7 +22,7 @@ const router = useRouter();
     }
   }
   return Object.values(map)
-});*/
+});
 
 const checkout = () => {
   storedOrder = JSON.parse(localStorage.getItem("order"));
@@ -154,9 +152,9 @@ const IsCheckoutDisabled = () => {
     <div>
       <!--  class="PiniaCart"-->
       <h1>Pinia Cart: </h1>
-      <div v-for="product in orderStore.order.products" :key="product.id" class="cart-item">
+      <div v-for="product in groupedList" :key="product.id" class="cart-item">
         <div>
-          <p>{{ product.name }} — {{ product.price }} kr</p>
+          <p>{{ product.name }} — {{ product.quantity }} x {{ product.price }} kr</p>
         </div>
         <div>
           <button @click="orderStore.removeProduct(product)">-</button> <!-- Name of method to remove product from Pinia cart might need to be updated once the method is implemented. -->

--- a/subway_project.client/src/components/CartNav.vue
+++ b/subway_project.client/src/components/CartNav.vue
@@ -14,9 +14,9 @@ const router = useRouter();
 
   // The computed property groupedList can be removed once adding and removing procucts from Pinia cart is implemented.
   // Or it can be updated to use the Pinia cart instead of the "props + emits" (i.e. receivedList) cart.
-/*const groupedList = computed(() => {
+const groupedList = computed(() => {
   const map = {}
-  for (const item of props.receivedList) {
+  for (const item of orderStore.order.products) {
     if (!map[item.name]) {
       map[item.name] = { ...item, quantity: 1 }
     } else {
@@ -24,7 +24,7 @@ const router = useRouter();
     }
   }
   return Object.values(map)
-});*/
+});
 
 const checkout = () => {
   storedOrder = JSON.parse(localStorage.getItem("order"));
@@ -154,9 +154,9 @@ const IsCheckoutDisabled = () => {
     <div>
       <!--  class="PiniaCart"-->
       <h1>Pinia Cart: </h1>
-      <div v-for="product in orderStore.order.products" :key="product.id" class="cart-item">
+      <div v-for="product in groupedList" :key="product.id" class="cart-item">
         <div>
-          <p>{{ product.name }} — {{ product.price }} kr</p>
+          <p>{{ product.name }} — {{ product.quantity }} x {{ product.price }} kr</p>
         </div>
         <div>
           <button @click="orderStore.removeProduct(product)">-</button> <!-- Name of method to remove product from Pinia cart might need to be updated once the method is implemented. -->

--- a/subway_project.client/src/components/TopNav.vue
+++ b/subway_project.client/src/components/TopNav.vue
@@ -1,11 +1,19 @@
 <script setup>
+  import { useOrderStore } from "@/stores/useOrderStore";
+  const orderStore = useOrderStore();
+
+  const resetCart = () => {
+    if (orderStore.order.products.length > 0) {
+      orderStore.resetOrder();
+    }
+  }
 </script>
 
 <template>
   <div class="top-nav-container">
     <div>
         <RouterLink to="/" class="bottom-link">
-            <img class="logo" src="../assets/imgs/SubWayNewLogo2.png" alt="Subway Logo">
+            <img class="logo" src="../assets/imgs/SubWayNewLogo2.png" alt="Subway Logo" @click="resetCart">
         </RouterLink>
     </div>
     <div class="page-links">

--- a/subway_project.client/src/views/OrderConfirmation.vue
+++ b/subway_project.client/src/views/OrderConfirmation.vue
@@ -16,11 +16,22 @@
   let redirectTimer = null;
   let countdownTimer = null;
 
+  const groupedList = (products) => {
+    const map = {}
+    for (const product of products) {
+      if (!map[product.name]) {
+        map[product.name] = { ...product, quantity: 1 }
+      } else {
+        map[product.name].quantity += 1
+      }
+    }
+    return Object.values(map)
+  };
 
-  const orderProductsSub = orderStore.order.products.filter(prod => prod.subCategoryId >= 1 && prod.subCategoryId <= 5);
-  const orderProductsDrinks = orderStore.order.products.filter(prod => prod.subCategoryId >= 6 && prod.subCategoryId <= 7);
-  const orderProductsSnacks = orderStore.order.products.filter(prod => prod.subCategoryId >= 8 && prod.subCategoryId <= 9);
-  const orderProductsDesserts = orderStore.order.products.filter(prod => prod.subCategoryId >= 10 && prod.subCategoryId <= 11);
+  const orderProductsSub = groupedList(orderStore.order.products.filter(prod => prod.subCategoryId >= 1 && prod.subCategoryId <= 5));
+  const orderProductsDrinks = groupedList(orderStore.order.products.filter(prod => prod.subCategoryId >= 6 && prod.subCategoryId <= 7));
+  const orderProductsSnacks = groupedList(orderStore.order.products.filter(prod => prod.subCategoryId >= 8 && prod.subCategoryId <= 9));
+  const orderProductsDesserts = groupedList(orderStore.order.products.filter(prod => prod.subCategoryId >= 10 && prod.subCategoryId <= 11));
 
   const startNewOrder = () => {
     orderStore.resetOrder();
@@ -64,25 +75,25 @@
       <div v-if="orderProductsSub.length !== 0">
         <p class="order-item-heading">Sub:</p>
         <ul>
-          <li v-for="product in orderProductsSub" :key="product.id" :id="`product-` + product.id">{{ product.name }} — {{ product.price }}kr</li>
+          <li v-for="product in orderProductsSub" :key="product.id" :id="`product-` + product.id">{{ product.name }} — {{ product.quantity }} x {{ product.price }}kr</li>
         </ul>
       </div>
       <div v-if="orderProductsDrinks.length !== 0">
         <p class="order-item-heading">Drinks:</p>
         <ul>
-          <li v-for="product in orderProductsDrinks" :key="product.id" :id="`product-` + product.id">{{ product.name }} — {{ product.price }}kr</li>
+          <li v-for="product in orderProductsDrinks" :key="product.id" :id="`product-` + product.id">{{ product.name }} — {{ product.quantity }} x {{ product.price }}kr</li>
         </ul>
       </div>
       <div v-if="orderProductsSnacks.length !== 0">
         <p class="order-item-heading">Snacks:</p>
         <ul>
-          <li v-for="product in orderProductsSnacks" :key="product.id" :id="`product-` + product.id">{{ product.name }} — {{ product.price }}kr</li>
+          <li v-for="product in orderProductsSnacks" :key="product.id" :id="`product-` + product.id">{{ product.name }} — {{ product.quantity }} x {{ product.price }}kr</li>
         </ul>
       </div>
       <div v-if="orderProductsDesserts.length !== 0">
         <p class="order-item-heading">Dessert:</p>
         <ul>
-          <li v-for="product in orderProductsDesserts" :key="product.id" :id="`product-` + product.id">{{ product.name }} — {{ product.price }}kr</li>
+          <li v-for="product in orderProductsDesserts" :key="product.id" :id="`product-` + product.id">{{ product.name }} — {{ product.quantity }} x {{ product.price }}kr</li>
         </ul>
       </div>
       <div class="order-footer">


### PR DESCRIPTION
- **Added reset of Pinia cart (if list of products in Pinia cart is not empty) when Subway logo is clicked in TopNav. So if Subway logo in top nav is clicked from OrderConfirmation page, instead of the 'Start new order' button, the order is not left in the cart.**
- **Grouped items of the same product on the OrderConfirmation page.**
- **Grouped items of the same product in CartNav. (multiple commits for this as I missed removing some comments and got a conflict when trying to amend most recent commit)**
