### PR TITLE
Refactored KitchenOrder to use CategoryId. Fixed rounding of VAT. Added migration following data model update allowing multiple subs per order.

### DIFF
--- a/subway_project.Server/Migrations/20250430124030_ModelRevision_MultipleSubsPerOrder.Designer.cs
+++ b/subway_project.Server/Migrations/20250430124030_ModelRevision_MultipleSubsPerOrder.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using subway_project.Server.Data;
 
@@ -11,9 +12,11 @@ using subway_project.Server.Data;
 namespace subway_project.Server.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250430124030_ModelRevision_MultipleSubsPerOrder")]
+    partial class ModelRevision_MultipleSubsPerOrder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/subway_project.Server/Migrations/20250430124030_ModelRevision_MultipleSubsPerOrder.cs
+++ b/subway_project.Server/Migrations/20250430124030_ModelRevision_MultipleSubsPerOrder.cs
@@ -1,0 +1,324 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace subway_project.Server.Migrations
+{
+    /// <inheritdoc />
+    public partial class ModelRevision_MultipleSubsPerOrder : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrderProduct_Orders_OrdersId",
+                table: "OrderProduct");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrderProduct_Products_ProductsId",
+                table: "OrderProduct");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Products_SubCategories_SubCategoryId",
+                table: "Products");
+
+            migrationBuilder.DropTable(
+                name: "Queues");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_OrderProduct",
+                table: "OrderProduct");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OrderProduct_ProductsId",
+                table: "OrderProduct");
+
+            migrationBuilder.RenameColumn(
+                name: "ProductsId",
+                table: "OrderProduct",
+                newName: "Quantity");
+
+            migrationBuilder.RenameColumn(
+                name: "OrdersId",
+                table: "OrderProduct",
+                newName: "ProductId");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Products",
+                type: "nvarchar(450)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AddColumn<int>(
+                name: "CategoryId",
+                table: "Products",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "CustomerId",
+                table: "Orders",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<bool>(
+                name: "TakeAway",
+                table: "Orders",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "OrderId",
+                table: "OrderProduct",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_OrderProduct",
+                table: "OrderProduct",
+                columns: new[] { "OrderId", "ProductId" });
+
+            migrationBuilder.CreateTable(
+                name: "Sub",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    OrderId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Sub", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Sub_Orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "Orders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "SubProduct",
+                columns: table => new
+                {
+                    SubId = table.Column<int>(type: "int", nullable: false),
+                    ProductId = table.Column<int>(type: "int", nullable: false),
+                    Quantity = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SubProduct", x => new { x.SubId, x.ProductId });
+                    table.ForeignKey(
+                        name: "FK_SubProduct_Products_ProductId",
+                        column: x => x.ProductId,
+                        principalTable: "Products",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SubProduct_Sub_SubId",
+                        column: x => x.SubId,
+                        principalTable: "Sub",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_CategoryId",
+                table: "Products",
+                column: "CategoryId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Products_Name",
+                table: "Products",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderProduct_ProductId",
+                table: "OrderProduct",
+                column: "ProductId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Sub_OrderId",
+                table: "Sub",
+                column: "OrderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SubProduct_ProductId",
+                table: "SubProduct",
+                column: "ProductId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrderProduct_Orders_OrderId",
+                table: "OrderProduct",
+                column: "OrderId",
+                principalTable: "Orders",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrderProduct_Products_ProductId",
+                table: "OrderProduct",
+                column: "ProductId",
+                principalTable: "Products",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Products_Categories_CategoryId",
+                table: "Products",
+                column: "CategoryId",
+                principalTable: "Categories",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Products_SubCategories_SubCategoryId",
+                table: "Products",
+                column: "SubCategoryId",
+                principalTable: "SubCategories",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrderProduct_Orders_OrderId",
+                table: "OrderProduct");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_OrderProduct_Products_ProductId",
+                table: "OrderProduct");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Products_Categories_CategoryId",
+                table: "Products");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Products_SubCategories_SubCategoryId",
+                table: "Products");
+
+            migrationBuilder.DropTable(
+                name: "SubProduct");
+
+            migrationBuilder.DropTable(
+                name: "Sub");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Products_CategoryId",
+                table: "Products");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Products_Name",
+                table: "Products");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_OrderProduct",
+                table: "OrderProduct");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OrderProduct_ProductId",
+                table: "OrderProduct");
+
+            migrationBuilder.DropColumn(
+                name: "CategoryId",
+                table: "Products");
+
+            migrationBuilder.DropColumn(
+                name: "CustomerId",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "TakeAway",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "OrderId",
+                table: "OrderProduct");
+
+            migrationBuilder.RenameColumn(
+                name: "Quantity",
+                table: "OrderProduct",
+                newName: "ProductsId");
+
+            migrationBuilder.RenameColumn(
+                name: "ProductId",
+                table: "OrderProduct",
+                newName: "OrdersId");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Products",
+                type: "nvarchar(max)",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(450)");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_OrderProduct",
+                table: "OrderProduct",
+                columns: new[] { "OrdersId", "ProductsId" });
+
+            migrationBuilder.CreateTable(
+                name: "Queues",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    OrderId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Queues", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Queues_Orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "Orders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderProduct_ProductsId",
+                table: "OrderProduct",
+                column: "ProductsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Queues_OrderId",
+                table: "Queues",
+                column: "OrderId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrderProduct_Orders_OrdersId",
+                table: "OrderProduct",
+                column: "OrdersId",
+                principalTable: "Orders",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrderProduct_Products_ProductsId",
+                table: "OrderProduct",
+                column: "ProductsId",
+                principalTable: "Products",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Products_SubCategories_SubCategoryId",
+                table: "Products",
+                column: "SubCategoryId",
+                principalTable: "SubCategories",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/subway_project.client/src/components/KitchenOrder.vue
+++ b/subway_project.client/src/components/KitchenOrder.vue
@@ -92,30 +92,30 @@
     </div>
 
         <!-- Drinks -->
-        <div v-if="groupedList(order.orderProducts.filter(op => op.product.subCategoryId >= 6 && op.product.subCategoryId <= 7)).length">
+        <div v-if="groupedList(order.orderProducts.filter(op => op.product.categoryId === 3)).length">
           <p><strong>Drinks:</strong></p>
           <ul>
-            <li v-for="op in groupedList(order.orderProducts.filter(op => op.product.subCategoryId >= 6 && op.product.subCategoryId <= 7))" :key="op.product.id">
+            <li v-for="op in groupedList(order.orderProducts.filter(op => op.product.categoryId === 3))" :key="op.product.id">
               {{ op.product.name }} x {{ op.quantity }}
             </li>
           </ul>
         </div>
 
         <!-- Snacks -->
-        <div v-if="groupedList(order.orderProducts.filter(op => op.product.subCategoryId >= 8 && op.product.subCategoryId <= 9)).length">
+        <div v-if="groupedList(order.orderProducts.filter(op => op.product.categoryId === 4)).length">
           <p><strong>Snacks:</strong></p>
           <ul>
-            <li v-for="op in groupedList(order.orderProducts.filter(op => op.product.subCategoryId >= 8 && op.product.subCategoryId <= 9))" :key="op.product.id">
+            <li v-for="op in groupedList(order.orderProducts.filter(op => op.product.categoryId === 4))" :key="op.product.id">
               {{ op.product.name }} x {{ op.quantity }}
             </li>
           </ul>
         </div>
 
         <!-- Desserts -->
-        <div v-if="groupedList(order.orderProducts.filter(op => op.product.subCategoryId >= 10 && op.product.subCategoryId <= 11)).length">
+        <div v-if="groupedList(order.orderProducts.filter(op => op.product.categoryId === 5)).length">
           <p><strong>Desserts:</strong></p>
           <ul>
-            <li v-for="op in groupedList(order.orderProducts.filter(op => op.product.subCategoryId >= 10 && op.product.subCategoryId <= 11))" :key="op.product.id">
+            <li v-for="op in groupedList(order.orderProducts.filter(op => op.product.categoryId === 5))" :key="op.product.id">
               {{ op.product.name }} x {{ op.quantity }}
             </li>
           </ul>

--- a/subway_project.client/src/views/OrderConfirmation.vue
+++ b/subway_project.client/src/views/OrderConfirmation.vue
@@ -179,7 +179,7 @@
       <p>Total: {{ orderStore.order.totalPrice }}kr</p>
       <div class="vat-container">
         <p class="vat">12% VAT:</p>
-        <p>{{orderStore.order.totalPrice * 0.12.toFixed(2)}}kr </p>
+        <p>{{(orderStore.order.totalPrice * 0.12).toFixed(2)}}kr </p>
       </div>
       <span>Thank you for your order!</span>
     </div>


### PR DESCRIPTION
- **Refactored KitchenOrder to use CategoryId instead of SubCategoryId in v-if for category headings.**
- **Fixed rounding of VAT so it rounds to 2 decimal points correctly in OrderConfirmation page.**
- **Migration having updated data model to allow multiple subs in one order.**
